### PR TITLE
Add `assemble` lambda function to replace ab2cb

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,16 @@ Slim List System
 
 Slim List is a AWS lambda based crawling system for evaluating which EasyList and EasyPrivacy rules are the most useful.  The main goal of the system is to shrink EasyList and EasyPrivacy so that they can be shipped in the iOS client.
 
-Slim list consists of many AWS parts: S3 for scratch and final resuls, SQS for job queing, and multiple lambdas, including the code included in this repo, along with [brave-experiments/brave-popular-filters-dat-builder](https://github.com/brave-experiments/brave-popular-filters-dat-builder) and [brave-experiments/brave-popular-filters-builder](https://github.com/brave-experiments/brave-popular-filters-builder).
+Slim list consists of many AWS parts: S3 for scratch and final resuls, SQS for job queing, and multiple lambdas included in this repo.
 
 How the Lambdas in the system interact
 ---
-1. This lambda function is the entry point to the whole system.  While its implemented as a single lambda function, its performs four distinct tasks.  In order:
+This lambda function is the entry point to the whole system.  While its implemented as a single lambda function, its performs five distinct tasks.  In order:
    1. [brave/lambda_actions/crawl-dispatch.js](https://github.com/brave/slim-list-lambda/blob/master/brave/lambda_actions/crawl-dispatch.js) fetches a new Alexa 10k list and then queues up the sites to crawl in SQS.  This function is called once per crawl.
    2. [brave/lambda_actions/crawl.js](https://github.com/brave/slim-list-lambda/blob/master/brave/lambda_actions/crawl.js) is called *per page* that needs to be crawled. It triggers a chrome instance to crawl a page, records everything thats fetched, writes a description of it to S3, and possibly kicks off more `brave/lambda_actions/crawl.js` instances to crawl child pages
    3. [brave/lambda_actions/record.js](https://github.com/brave/slim-list-lambda/blob/master/brave/lambda_actions/record.js) is also called once for each page that is mesured.  This invocation reads all the seralized data from the `crawl.js` invocation, and writes it to postgres.  (This is a separate step to reduce the number of parallel jobs triggered in 1.iii, to avoid sinking the DB).
    4. [brave/lambda_actions/build.js](https://github.com/brave/slim-list-lambda/blob/master/brave/lambda_actions/build.js) does the DB side analysis to determine which filter lists rules are popular enough to be included in “slim list”.  It is also called once per crawl.
-2. Some time later, [brave-popular-filters-builder](https://github.com/brave-experiments/brave-popular-filters-builder) is called.  This takes the slim list data, combines it with brave owned / authored lists, and coverts it to iOS format and stores the result in S3.  (This function is implemented seperately because it needs to be in python, to call the ab2cb conversion library.
-3. Finally, the above function calls [brave-popular-filters-dat-builder](https://github.com/brave-experiments/brave-popular-filters-dat-builder), once for each filter list (the main iOS one, and each regional list) and generates .dat / adblock-rs format versions of each list, which are also stored in S3.  This is its own function bc it needs to use the node runtime, bc there are not currently python bindings for adblock-rs.
+   5. [brave/lambda_actions/assemble.js](https://github.com/brave/slim-list-lambda/blob/master/brave/lambda_actions/assemble.js) combines the slim list data with brave owned/authored lists, and produces an iOS content blocking rule file, as well as a corresponding DAT file to be loaded by adblock-rust browser-side. It will do this for each regional list as well. All of the outputs are stored in S3.
 
 Structure of S3 Crawl Data
 ---

--- a/brave/lambda_actions/assemble.js
+++ b/brave/lambda_actions/assemble.js
@@ -1,0 +1,168 @@
+'use strict'
+
+const requestPromiseLib = require('request-promise')
+const { Engine, FilterSet, FilterFormat, RuleTypes } = require('adblock-rs')
+
+const braveDebugLib = require('../debug')
+const braveS3Lib = require('../s3')
+const braveValidationLib = require('../validation')
+
+// Static lists that we use entirely in the default set of filters
+const COIN_MINER_URL = 'https://raw.githubusercontent.com/brave/adblock-lists/master/coin-miners.txt'
+const BREAK_UNBREAK_URL = 'https://raw.githubusercontent.com/brave/adblock-lists/master/brave-unbreak.txt'
+const UBLOCK_UNBREAK_URL = 'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt'
+const NOTIFICATIONS_URL = 'https://easylist-downloads.adblockplus.org/fanboy-notifications.txt'
+const STATIC_RULE_URLS = [COIN_MINER_URL, BREAK_UNBREAK_URL, UBLOCK_UNBREAK_URL, NOTIFICATIONS_URL]
+
+const REGIONAL_CATALOG_URL = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/regional.json'
+
+/**
+ * @file
+ * Lambda action for assembling adblock-rust DAT files and iOS content-blocking
+ * files from the slim list.
+ */
+
+/**
+ * Check whether the given invocation arguments for the lambda are valid,
+ * and return a version of them that are valid, after doing things like
+ * filling in optional arguments, etc.
+ *
+ * Optional arguments
+ *  - slimListS3Bucket {string}
+ *      The S3 bucket to read from. Defaults to `adblock-data`
+ *  - slimListS3Key {string}
+ *      The S3 key to read slim list from.  Defaults to `slim-list/latest.json`
+ *  - destS3Bucket {string}
+ *      The S3 bucket to write to. Defaults to `adblock-data`
+ *  - bucketOwner {string}
+ *      The Canonical ID of the account which owns destS3Bucket.
+ *      Defaults to 'id="eb241751bdcc963195c53b3df68bfe8855c629a972a2a787006db80b1d40caa8"'
+ *
+ * @return [bool, object|string]
+ *   Returns either false, and then a string describing the error in the
+ *   arguments, or true, and a frozen object with arguments prepared for
+ *   operating on.
+ */
+const validateArgs = async inputArgs => {
+  const isString = braveValidationLib.ofTypeAndTruthy.bind(undefined, 'string')
+  const validationRules = {
+    slimListS3Bucket: {
+      validate: isString,
+      default: 'adblock-data'
+    },
+    slimListS3Key: {
+      validate: isString,
+      default: 'slim-list/latest.json'
+    },
+    destS3Bucket: {
+      validate: isString,
+      default: 'adblock-data'
+    },
+    bucketOwner: {
+      validate: isString,
+      default: 'id="eb241751bdcc963195c53b3df68bfe8855c629a972a2a787006db80b1d40caa8"'
+    }
+  }
+
+  const [isValid, msg] = braveValidationLib.applyValidationRules(
+    inputArgs, validationRules)
+
+  if (isValid === false) {
+    return [false, msg]
+  }
+
+  return [true, Object.freeze(msg)]
+}
+
+/**
+ * Lambda function to build content blocking rules and a corresponding DAT file
+ * from an existing slim-list.
+ */
+const start = async args => {
+  const rulesToAssemble = JSON.parse((await braveS3Lib.read(args.slimListS3Bucket, args.slimListS3Key)).toString('utf8'))
+
+  if (rulesToAssemble.length === 0) {
+    const errMsg = '0 rules were fetched from the slim list bucket. This should never happen.'
+    throw Error(errMsg)
+  }
+
+  braveDebugLib.log(`Fetched ${rulesToAssemble.length} rules from the slim list bucket.`)
+
+  braveDebugLib.log('About to fetch and add rules from static lists')
+  const staticRuleLists = await Promise.all(STATIC_RULE_URLS.map(requestPromiseLib))
+  for (const staticRuleList of staticRuleLists) {
+    const staticRules = staticRuleList.split('\n')
+    rulesToAssemble.push(...staticRules)
+  }
+  braveDebugLib.log(`Successfully added rules from static lists, got ${rulesToAssemble.length} rules in total`)
+
+  braveDebugLib.log('About to convert default list to iOS content blocking syntax')
+  const { contentBlockingRules, datBuffer, filtersUsed } = convertRules(rulesToAssemble, FilterFormat.STANDARD)
+  const readAcl = 'uri="http://acs.amazonaws.com/groups/global/AllUsers"'
+  braveDebugLib.log('Saving the set of default rules used')
+  await braveS3Lib.write(args.destS3Bucket, 'ios/latest.txt', filtersUsed, readAcl, args.bucketOwner)
+
+  braveDebugLib.log('Saving the new default content-blocking rules')
+  await braveS3Lib.write(args.destS3Bucket, 'ios/latest.json', contentBlockingRules, readAcl, args.bucketOwner)
+
+  braveDebugLib.log('Saving the new default DAT')
+  await braveS3Lib.write(args.destS3Bucket, 'ios/latest.dat', datBuffer, readAcl, args.bucketOwner)
+
+  const regionalCatalog = JSON.parse(await requestPromiseLib(REGIONAL_CATALOG_URL))
+  for (const regionalList of regionalCatalog) {
+    const regionalListContent = (await requestPromiseLib(regionalList.url)).trim()
+    if (regionalListContent.length === 0) {
+      console.error(`${regionalList.title} returned an empty result. Skipping.`)
+      continue
+    }
+    const rules = regionalListContent.split('\n')
+    braveDebugLib.log(`About to convert ${regionalList.title} to iOS content blocking syntax`)
+    const { contentBlockingRules, datBuffer, filtersUsed } = convertRules(rules, regionalList.format)
+    braveDebugLib.log(`Saving the set of rules used from ${regionalList.title}`)
+    await braveS3Lib.write(args.destS3Bucket, `ios/${regionalList.uuid}-latest.txt`, filtersUsed, readAcl, args.bucketOwner)
+
+    braveDebugLib.log(`Saving the new content-blocking rules for ${regionalList.title}`)
+    await braveS3Lib.write(args.destS3Bucket, `ios/${regionalList.uuid}-latest.json`, contentBlockingRules, readAcl, args.bucketOwner)
+
+    braveDebugLib.log(`Saving the new DAT for ${regionalList.title}`)
+    await braveS3Lib.write(args.destS3Bucket, `ios/${regionalList.uuid}-latest.dat`, datBuffer, readAcl, args.bucketOwner)
+  }
+}
+
+// Converts a single list of rules (all in the same format) to content blocking and DAT representations.
+//
+// Returns { contentBlockingRules, datBuffer } as a JSON string and Buffer, respectively.
+const convertRules = (rules, format) => {
+  const filterSet = new FilterSet(true)
+  filterSet.addFilters(rules, format)
+
+  const { contentBlockingRules, filtersUsed } = filterSet.intoContentBlocking(RuleTypes.NETWORK_ONLY)
+  braveDebugLib.log(`Successfully converted ${filtersUsed.length} into ${contentBlockingRules.length} content blocking rules`)
+
+  if (filtersUsed.length === 0 || contentBlockingRules.length === 0) {
+    const errMsg = 'Looks like something is wrong with adblock-rust. ' +
+                   'There should never be zero rules generated.'
+    throw Error(errMsg)
+  }
+
+  braveDebugLib.log('About to serialize a DAT from the successfully converted rules')
+  const iosFilterSet = new FilterSet(true)
+  iosFilterSet.addFilters(filtersUsed)
+  const engine = new Engine(iosFilterSet, { optimize: false })
+  const iosDat = engine.serialize()
+  const datBuffer = Buffer.from(iosDat)
+
+  if (datBuffer.byteLength === 0) {
+    const errMsg = 'Looks like something is wrong with adblock-rust. ' +
+                   'The generated DAT was empty.'
+    throw Error(errMsg)
+  }
+  braveDebugLib.log(`Successfully serialized rules into buffer of length ${datBuffer.byteLength}`)
+
+  return { contentBlockingRules: JSON.stringify(contentBlockingRules), datBuffer, filtersUsed: filtersUsed.join('\n') }
+}
+
+module.exports = {
+  validateArgs,
+  start
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,9 +136,8 @@
       "dev": true
     },
     "adblock-rs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.0.tgz",
-      "integrity": "sha512-r3onaSiW5oxMoLUj1UAJuPeYXmonTZ5hMh1uM8DxSWHZF88iG/qyFZ3p+UdGaLIRe0A2x94KiQO/OBr/F+6Hyg==",
+      "version": "github:brave/adblock-rust#d75f0cedb09492dfb030b1023044b77cb49ce824",
+      "from": "github:brave/adblock-rust#content-blocking",
       "requires": {
         "neon-cli": "0.4.0"
       }
@@ -721,11 +720,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "devtools-protocol": {
-      "version": "0.0.781568",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.781568.tgz",
-      "integrity": "sha512-9Uqnzy6m6zEStluH9iyJ3iHyaQziFnMnLeC8vK0eN6smiJmIx7+yB64d67C2lH/LZra+5cGscJAJsNXO+MdPMg=="
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1266,9 +1260,9 @@
       },
       "dependencies": {
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "requires": {
             "pump": "^3.0.0"
           }
@@ -2725,16 +2719,14 @@
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
     "puppeteer-core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.2.1.tgz",
-      "integrity": "sha512-gLjEOrzwgcnwRH+sm4hS1TBqe2/DN248nRb2hYB7+lZ9kCuLuACNvuzlXILlPAznU3Ob+mEvVEBDcLuFa0zq3g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.3.0.tgz",
+      "integrity": "sha512-hynQ3r0J/lkGrKeBCqu160jrj0WhthYLIzDQPkBxLzxPokjw4elk1sn6mXAian/kfD2NRzpdh9FSykxZyL56uA==",
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.781568",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
         "mime": "^2.0.3",
-        "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^3.0.2",
@@ -2743,57 +2735,6 @@
         "ws": "^7.2.3"
       },
       "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-        },
-        "pkg-dir": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-          "requires": {
-            "find-up": "^4.0.0"
-          }
-        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -3529,9 +3470,9 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
+      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
       "optional": true
     },
     "unbzip2-stream": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/brave-experiments/slim-list-lambda#readme",
   "dependencies": {
-    "adblock-rs": "^0.3.0",
+    "adblock-rs": "github:brave/adblock-rust#content-blocking",
     "aws-sdk": "^2.574.0",
     "aws-xray-sdk": "^2.5.0",
     "chrome-aws-lambda": "^3.1.1",

--- a/slim-list-lambdas.yaml
+++ b/slim-list-lambdas.yaml
@@ -22,6 +22,11 @@ Parameters:
     Description: "Flag to defined verbosity. Default setting is 0."
     Type: Number
     Default: 0
+  SlimListAssembleLambdaExecutionRole:
+    Description: "IAM Role for Slim List Assemble Lambda"
+    Type: "AWS::SSM::Parameter::Value<String>"
+    Default: "/DeploymentConfig/SlimList/Lambda/\
+      AssembleLambdaExecutionRoleArn"
   SlimListBuildLambdaExecutionRole:
     Description: "IAM Role for Slim List Build Lambda"
     Type: "AWS::SSM::Parameter::Value<String>"
@@ -81,6 +86,10 @@ Parameters:
     Description: "Slim List Build Lambda DLQ"
     Type: "AWS::SSM::Parameter::Value<String>"
     Default: "/DeploymentConfig/SQS/BuildQueue"
+  SlimListAssembleDLQ:
+    Description: "Slim List Assemble Lambda DLQ"
+    Type: "AWS::SSM::Parameter::Value<String>"
+    Default: "/DeploymentConfig/SQS/AssembleQueue"
 
 Resources:
   SlimListCrawlDispatchLambda:
@@ -206,7 +215,7 @@ Resources:
       Namespace: AWS/Lambda
       OKActions:
         - !Ref SlimListLambdaSNSArn
-      Period: 604800
+      Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
       Threshold: 1
@@ -233,7 +242,7 @@ Resources:
       Namespace: AWS/Lambda
       OKActions:
         - !Ref SlimListLambdaSNSArn
-      Period: 604800
+      Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
       Threshold: 1
@@ -371,7 +380,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
-      Period: 604800
+      Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
       Threshold: 1
@@ -394,7 +403,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
-      Period: 604800
+      Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
       Threshold: 1
@@ -533,7 +542,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
-      Period: 604800
+      Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
       Threshold: 1
@@ -556,7 +565,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
-      Period: 604800
+      Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
       Threshold: 1
@@ -725,7 +734,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
-      Period: 604800
+      Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
       Threshold: 1
@@ -748,7 +757,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
-      Period: 604800
+      Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
       Threshold: 1
@@ -774,3 +783,197 @@ Resources:
         BusinessUnit: brave-core
         Project: "https://github.com/brave/devops/projects/29"
         RequestID: "https://github.com/brave/devops/issues/2112"
+
+  SlimListAssembleLambda:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      Description: "Lambda function that combines the slim list data
+        with Brave owned/authored lists, and produces an iOS content blocking
+        rule file as well as a corresponding DAT file to be loaded
+        by adblock-rust browser-side."
+      Handler: "index.dispatch"
+      Runtime: nodejs12.x
+      CodeUri: ./build/slim-list-generator.zip
+      Timeout: 900
+      MemorySize: 2048
+      Environment:
+        Variables:
+          DEBUG: !Ref DebugFlag
+          PG_USERNAME: !Ref DatabaseUserName
+          PG_HOSTNAME: !Ref DatabaseHostName
+          PG_PASSWORD: '{{resolve:secretsmanager:slim-list-aurora-password}}'
+          PG_PORT: !Ref DatabasePort
+          VERBOSE: !Ref VerboseFlag
+      Tracing: !Ref TracingFlag
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !Ref SlimListAssembleDLQ
+      Role: !Ref SlimListAssembleLambdaExecutionRole
+      AutoPublishAlias: !Ref DeploymentEnvironment
+      DeploymentPreference:
+        Type: AllAtOnce
+        Alarms:
+          - !Ref AliasBuildErrorMetricGreaterThanZeroAlarm
+          - !Ref LatestBuildVersionErrorMetricGreaterThanZeroAlarm
+      Tags:
+        Name: slim-list-lambda-assemble
+        ApplicationID: slim-list
+        ResourceName: slim-list-lambda-assemble
+        Security: private
+        Owner: brave-core
+        Environment: !Ref DeploymentEnvironment
+        BusinessUnit: brave-core
+        Project: "https://github.com/brave/devops/projects/29"
+        RequestID: "https://github.com/brave/slim-list-lambda/pull/17"
+
+  SlimListAssembleLambdaLogGroup:
+    Type: "AWS::Logs::LogGroup"
+    DependsOn: SlimListAssembleLambda
+    Properties:
+      LogGroupName:
+        Fn::Join:
+          - ''
+          - - '/aws/lambda/'
+            - !Ref SlimListAssembleLambda
+      RetentionInDays: 7
+
+  SlimListAssembleLambdaMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    DependsOn: SlimListAssembleLambdaLogGroup
+    Properties:
+      LogGroupName:
+        !Ref SlimListAssembleLambdaLogGroup
+      FilterPattern: "Found 0 recently used exception rules"
+      MetricTransformations:
+        -
+          MetricValue: "1"
+          MetricNamespace: "SlimListAssembleLambda/MetricFilter"
+          MetricName: "SlimListAssembleLambdaMetricFilter"
+
+  AssembleLambdaErrorMetricFilterGreaterThanZeroAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    DependsOn: SlimListAssembleLambdaMetricFilter
+    Properties:
+      AlarmDescription: Found 0 recently used exception rules
+      AlarmActions:
+        - !Ref SlimListLambdaSNSArn
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 2
+      MetricName: SlimListAssembleLambdaMetricFilter
+      Namespace: SlimListAssembleLambda/MetricFilter
+      OKActions:
+        - !Ref SlimListLambdaSNSArn
+      Period: 60
+      Statistic: Sum
+      TreatMissingData: notBreaching
+      Threshold: 0
+
+  AliasAssembleErrorMetricGreaterThanZeroAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: Lambda Function Error > 0
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Resource
+          Value: !Join
+            - ':'
+            - - !Sub "${SlimListAssembleLambda}"
+              - !Ref DeploymentEnvironment
+        - Name: FunctionName
+          Value: !Ref SlimListAssembleLambda
+      EvaluationPeriods: 2
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      TreatMissingData: notBreaching
+      Threshold: 0
+
+  LatestAssembleVersionErrorMetricGreaterThanZeroAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: Lambda Function Error > 0
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Resource
+          Value: !Join
+            - ':'
+            - - !Sub "${SlimListAssembleLambda}"
+              - !Ref DeploymentEnvironment
+        - Name: FunctionName
+          Value: !Ref SlimListAssembleLambda
+        - Name: ExecutedVersion
+          Value: !GetAtt SlimListAssembleLambda.Version.Version
+      EvaluationPeriods: 2
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      TreatMissingData: notBreaching
+      Threshold: 0
+
+  AliasAssembleWeeklyInvocationMetricAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: Lambda Function Invocations < 1
+      ComparisonOperator: LessThanThreshold
+      Dimensions:
+        - Name: Resource
+          Value: !Join
+            - ':'
+            - - !Sub "${SlimListAssembleLambda}"
+              - !Ref DeploymentEnvironment
+        - Name: FunctionName
+          Value: !Ref SlimListAssembleLambda
+      EvaluationPeriods: 1
+      MetricName: Invocations
+      Namespace: AWS/Lambda
+      Period: 86400
+      Statistic: Sum
+      TreatMissingData: breaching
+      Threshold: 1
+
+  LatestAssembleVersionWeeklyInvocationMetricAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: Lambda Function Invocations < 1
+      ComparisonOperator: LessThanThreshold
+      Dimensions:
+        - Name: Resource
+          Value: !Join
+            - ':'
+            - - !Sub "${SlimListAssembleLambda}"
+              - !Ref DeploymentEnvironment
+        - Name: FunctionName
+          Value: !Ref SlimListAssembleLambda
+        - Name: ExecutedVersion
+          Value: !GetAtt SlimListAssembleLambda.Version.Version
+      EvaluationPeriods: 1
+      MetricName: Invocations
+      Namespace: AWS/Lambda
+      Period: 86400
+      Statistic: Sum
+      TreatMissingData: breaching
+      Threshold: 1
+
+  SsmAssembleLambdaArn:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: "/DeploymentConfig/SlimList/Resources/\
+        Lambda/Assemble/LambdaArn"
+      Type: "String"
+      Value:
+        Fn::GetAtt:
+          - SlimListAssembleLambda
+          - Arn
+      Description: "Resource ARN for Assemble Lambda for Slim List"
+      Tags:
+        Name: ssm-slim-list-lambda-assemble
+        ApplicationID: slim-list
+        ResourceName: slim-list-lambda-assemble
+        Security: private
+        Owner: brave-core
+        Environment: !Ref DeploymentEnvironment
+        BusinessUnit: brave-core
+        Project: "https://github.com/brave/devops/projects/29"
+        RequestID: "https://github.com/brave/slim-list-lambda/pull/17"

--- a/slim-list-lambdas.yaml
+++ b/slim-list-lambdas.yaml
@@ -210,7 +210,7 @@ Resources:
               - !Ref DeploymentEnvironment
         - Name: FunctionName
           Value: !Ref SlimListCrawlDispatchLambda
-      EvaluationPeriods: 1
+      EvaluationPeriods: 7
       MetricName: Invocations
       Namespace: AWS/Lambda
       OKActions:
@@ -237,7 +237,7 @@ Resources:
           Value: !Ref SlimListCrawlDispatchLambda
         - Name: ExecutedVersion
           Value: !GetAtt SlimListCrawlDispatchLambda.Version.Version
-      EvaluationPeriods: 1
+      EvaluationPeriods: 7
       MetricName: Invocations
       Namespace: AWS/Lambda
       OKActions:
@@ -731,7 +731,7 @@ Resources:
               - !Ref DeploymentEnvironment
         - Name: FunctionName
           Value: !Ref SlimListBuildLambda
-      EvaluationPeriods: 1
+      EvaluationPeriods: 7
       MetricName: Invocations
       Namespace: AWS/Lambda
       Period: 86400
@@ -754,7 +754,7 @@ Resources:
           Value: !Ref SlimListBuildLambda
         - Name: ExecutedVersion
           Value: !GetAtt SlimListBuildLambda.Version.Version
-      EvaluationPeriods: 1
+      EvaluationPeriods: 7
       MetricName: Invocations
       Namespace: AWS/Lambda
       Period: 86400
@@ -925,7 +925,7 @@ Resources:
               - !Ref DeploymentEnvironment
         - Name: FunctionName
           Value: !Ref SlimListAssembleLambda
-      EvaluationPeriods: 1
+      EvaluationPeriods: 7
       MetricName: Invocations
       Namespace: AWS/Lambda
       Period: 86400
@@ -948,7 +948,7 @@ Resources:
           Value: !Ref SlimListAssembleLambda
         - Name: ExecutedVersion
           Value: !GetAtt SlimListAssembleLambda.Version.Version
-      EvaluationPeriods: 1
+      EvaluationPeriods: 7
       MetricName: Invocations
       Namespace: AWS/Lambda
       Period: 86400

--- a/slim-list-lambdas.yaml
+++ b/slim-list-lambdas.yaml
@@ -141,7 +141,7 @@ Resources:
           - ''
           - - '/aws/lambda/'
             - !Ref SlimListCrawlDispatchLambda
-      RetentionInDays: 7
+      RetentionInDays: 14
 
   AliasCrawlDispatchErrorMetricGreaterThanZeroAlarm:
     Type: "AWS::CloudWatch::Alarm"
@@ -210,7 +210,7 @@ Resources:
               - !Ref DeploymentEnvironment
         - Name: FunctionName
           Value: !Ref SlimListCrawlDispatchLambda
-      EvaluationPeriods: 7
+      EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
       OKActions:
@@ -218,7 +218,7 @@ Resources:
       Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
-      Threshold: 1
+      Threshold: 7
 
   LatestCrawlDispatchVersionWeeklyInvocationMetricAlarm:
     Type: "AWS::CloudWatch::Alarm"
@@ -237,7 +237,7 @@ Resources:
           Value: !Ref SlimListCrawlDispatchLambda
         - Name: ExecutedVersion
           Value: !GetAtt SlimListCrawlDispatchLambda.Version.Version
-      EvaluationPeriods: 7
+      EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
       OKActions:
@@ -245,7 +245,7 @@ Resources:
       Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
-      Threshold: 1
+      Threshold: 7
 
   SsmCrawlDispatchLambdaArn:
     Type: "AWS::SSM::Parameter"
@@ -318,7 +318,7 @@ Resources:
           - ''
           - - '/aws/lambda/'
             - !Ref SlimListCrawlLambda
-      RetentionInDays: 7
+      RetentionInDays: 14
 
   AliasCrawlErrorMetricGreaterThanZeroAlarm:
     Type: "AWS::CloudWatch::Alarm"
@@ -480,7 +480,7 @@ Resources:
           - ''
           - - '/aws/lambda/'
             - !Ref SlimListRecordLambda
-      RetentionInDays: 7
+      RetentionInDays: 14
 
   AliasRecordErrorMetricGreaterThanZeroAlarm:
     Type: "AWS::CloudWatch::Alarm"
@@ -641,7 +641,7 @@ Resources:
           - ''
           - - '/aws/lambda/'
             - !Ref SlimListBuildLambda
-      RetentionInDays: 7
+      RetentionInDays: 14
 
   SlimListBuildLambdaMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -731,13 +731,13 @@ Resources:
               - !Ref DeploymentEnvironment
         - Name: FunctionName
           Value: !Ref SlimListBuildLambda
-      EvaluationPeriods: 7
+      EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
       Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
-      Threshold: 1
+      Threshold: 7
 
   LatestBuildVersionWeeklyInvocationMetricAlarm:
     Type: "AWS::CloudWatch::Alarm"
@@ -754,13 +754,13 @@ Resources:
           Value: !Ref SlimListBuildLambda
         - Name: ExecutedVersion
           Value: !GetAtt SlimListBuildLambda.Version.Version
-      EvaluationPeriods: 7
+      EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
       Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
-      Threshold: 1
+      Threshold: 7
 
   SsmBuildLambdaArn:
     Type: "AWS::SSM::Parameter"
@@ -835,7 +835,7 @@ Resources:
           - ''
           - - '/aws/lambda/'
             - !Ref SlimListAssembleLambda
-      RetentionInDays: 7
+      RetentionInDays: 14
 
   SlimListAssembleLambdaMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -925,13 +925,13 @@ Resources:
               - !Ref DeploymentEnvironment
         - Name: FunctionName
           Value: !Ref SlimListAssembleLambda
-      EvaluationPeriods: 7
+      EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
       Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
-      Threshold: 1
+      Threshold: 7
 
   LatestAssembleVersionWeeklyInvocationMetricAlarm:
     Type: "AWS::CloudWatch::Alarm"
@@ -948,13 +948,13 @@ Resources:
           Value: !Ref SlimListAssembleLambda
         - Name: ExecutedVersion
           Value: !GetAtt SlimListAssembleLambda.Version.Version
-      EvaluationPeriods: 7
+      EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
       Period: 86400
       Statistic: Sum
       TreatMissingData: breaching
-      Threshold: 1
+      Threshold: 7
 
   SsmAssembleLambdaArn:
     Type: "AWS::SSM::Parameter"


### PR DESCRIPTION
This adds a new lambda action called `assemble`, which should fully replace https://github.com/brave-experiments/brave-popular-filters-builder and https://github.com/brave-experiments/brave-popular-filters-dat-builder

Still left to do:
 - Run on staging to confirm correct functionality