### PR TITLE
update to upstream adblock-rs 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,8 +136,9 @@
       "dev": true
     },
     "adblock-rs": {
-      "version": "github:brave/adblock-rust#d75f0cedb09492dfb030b1023044b77cb49ce824",
-      "from": "github:brave/adblock-rust#content-blocking",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.2.tgz",
+      "integrity": "sha512-ZA2zTHDpeBkjV4GuT6lPM3kmET+4jkzD76fqOis7LUwYUMSWpl6/Cew5ez23or+59mLV7Jv1RKw3b0GW2PTLOQ==",
       "requires": {
         "neon-cli": "0.4.0"
       }
@@ -3470,9 +3471,9 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-js": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
-      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.2.tgz",
+      "integrity": "sha512-GXCYNwqoo0MbLARghYjxVBxDCnU0tLqN7IPLdHHbibCb1NI5zBkU2EPcy/GaVxc0BtTjqyGXJCINe6JMR2Dpow==",
       "optional": true
     },
     "unbzip2-stream": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/brave-experiments/slim-list-lambda#readme",
   "dependencies": {
-    "adblock-rs": "github:brave/adblock-rust#content-blocking",
+    "adblock-rs": "^0.3.2",
     "aws-sdk": "^2.574.0",
     "aws-xray-sdk": "^2.5.0",
     "chrome-aws-lambda": "^3.1.1",


### PR DESCRIPTION
Just merged the `content-blocking` branch into a new release of `adblock-rs`. Updating the dependency here to use the upstream version rather than a merged branch.