### PR TITLE
Support first-party document exceptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,9 +136,9 @@
       "dev": true
     },
     "adblock-rs": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.2.tgz",
-      "integrity": "sha512-ZA2zTHDpeBkjV4GuT6lPM3kmET+4jkzD76fqOis7LUwYUMSWpl6/Cew5ez23or+59mLV7Jv1RKw3b0GW2PTLOQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.3.tgz",
+      "integrity": "sha512-aiEAOzvJJHCPE+4LR8nV0Vt5TiJ1Ekg/Tl9XAFYBph8GUe393y/NV3DGH07JIIe7QNl33di6OJyNNC9WUa3+sw==",
       "requires": {
         "neon-cli": "0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/brave-experiments/slim-list-lambda#readme",
   "dependencies": {
-    "adblock-rs": "^0.3.2",
+    "adblock-rs": "^0.3.3",
     "aws-sdk": "^2.574.0",
     "aws-xray-sdk": "^2.5.0",
     "chrome-aws-lambda": "^3.1.1",


### PR DESCRIPTION
Updates adblock-rust to include the change from version 0.3.3