### PR TITLE
Update adblock-rust to v0.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4745,9 +4745,9 @@
       "dev": true
     },
     "adblock-rs": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.5.tgz",
-      "integrity": "sha512-RLyQVeL/+Cjym+lDGoQpVHxahVbERpNr7X76jhBQgvYfpOoq5xP7V9AhXQnKVMTv5PmCVc9Q1TcxCUrx5buOkw==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.6.tgz",
+      "integrity": "sha512-9r9sohqvVO8i3BwO1G6cCzy9/jL1KrLOCVHf/mgGvDtdpv/ibDaTHnk+gQsf5uPCYNIHpHaN2pBeatj3jofrVg==",
       "requires": {
         "neon-cli": "0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/brave-experiments/slim-list-lambda#readme",
   "dependencies": {
-    "adblock-rs": "^0.3.5",
+    "adblock-rs": "0.3.6",
     "aws-sdk": "^2.574.0",
     "aws-xray-sdk": "^3.2.0",
     "chrome-aws-lambda": "^7.0.0",


### PR DESCRIPTION
Includes a fix for a small issue with v0.3.5. Unfortunately this means full-regex rules still won't be converted - see https://github.com/brave/adblock-rust/issues/156 for more details.