### PR TITLE
Update adblock-rust to v0.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4745,9 +4745,9 @@
       "dev": true
     },
     "adblock-rs": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.3.tgz",
-      "integrity": "sha512-aiEAOzvJJHCPE+4LR8nV0Vt5TiJ1Ekg/Tl9XAFYBph8GUe393y/NV3DGH07JIIe7QNl33di6OJyNNC9WUa3+sw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.5.tgz",
+      "integrity": "sha512-RLyQVeL/+Cjym+lDGoQpVHxahVbERpNr7X76jhBQgvYfpOoq5xP7V9AhXQnKVMTv5PmCVc9Q1TcxCUrx5buOkw==",
       "requires": {
         "neon-cli": "0.4.0"
       }
@@ -6262,9 +6262,9 @@
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -8151,9 +8151,9 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-js": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.2.tgz",
-      "integrity": "sha512-GXCYNwqoo0MbLARghYjxVBxDCnU0tLqN7IPLdHHbibCb1NI5zBkU2EPcy/GaVxc0BtTjqyGXJCINe6JMR2Dpow==",
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
       "optional": true
     },
     "unbzip2-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4745,9 +4745,9 @@
       "dev": true
     },
     "adblock-rs": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.5.tgz",
-      "integrity": "sha512-RLyQVeL/+Cjym+lDGoQpVHxahVbERpNr7X76jhBQgvYfpOoq5xP7V9AhXQnKVMTv5PmCVc9Q1TcxCUrx5buOkw==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.6.tgz",
+      "integrity": "sha512-9r9sohqvVO8i3BwO1G6cCzy9/jL1KrLOCVHf/mgGvDtdpv/ibDaTHnk+gQsf5uPCYNIHpHaN2pBeatj3jofrVg==",
       "requires": {
         "neon-cli": "0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/brave-experiments/slim-list-lambda#readme",
   "dependencies": {
-    "adblock-rs": "^0.3.3",
+    "adblock-rs": "^0.3.5",
     "aws-sdk": "^2.574.0",
     "aws-xray-sdk": "^3.2.0",
     "chrome-aws-lambda": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/brave-experiments/slim-list-lambda#readme",
   "dependencies": {
-    "adblock-rs": "^0.3.5",
+    "adblock-rs": "0.3.6",
     "aws-sdk": "^2.574.0",
     "aws-xray-sdk": "^3.2.0",
     "chrome-aws-lambda": "^7.0.0",


### PR DESCRIPTION
@mihaiplesa this just contains some miscellaneous fixes from the last few months. I verified that v0.3.5 looked good when deployed from `staging`, apart from one minor change that I just fixed in v0.3.6.