### PR TITLE
Update adblock-rust to v0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,9 +136,9 @@
       "dev": true
     },
     "adblock-rs": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.3.tgz",
-      "integrity": "sha512-aiEAOzvJJHCPE+4LR8nV0Vt5TiJ1Ekg/Tl9XAFYBph8GUe393y/NV3DGH07JIIe7QNl33di6OJyNNC9WUa3+sw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.7.tgz",
+      "integrity": "sha512-BHbIKexaYoZ/xZIG8a4kFg902Wct4hDq/GDoIz7AZwBNesi6Osh7fPLAm2bHpPRFwtzHiaX64+tIQ6z07jdkWQ==",
       "requires": {
         "neon-cli": "0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/brave-experiments/slim-list-lambda#readme",
   "dependencies": {
-    "adblock-rs": "^0.3.3",
+    "adblock-rs": "^0.3.7",
     "aws-sdk": "^2.574.0",
     "aws-xray-sdk": "^2.5.0",
     "chrome-aws-lambda": "^3.1.1",


### PR DESCRIPTION
I received [a report](https://github.com/brave/adblock-rust/issues/161) from the community that the iOS content blocking format generation code was not able to handle the rule `@@||googletagservices.com/tag/js/gpt.js$domain=allestoringen.nl|allestörungen.at` (which was recently added) because of the unicode in the `$domain` option.

I've since published adblock-rust v0.3.7 which is able to handle this case correctly.