### PR TITLE
Include Brave IOS specific list

### DIFF
--- a/brave/lambda_actions/assemble.js
+++ b/brave/lambda_actions/assemble.js
@@ -12,7 +12,8 @@ const COIN_MINER_URL = 'https://raw.githubusercontent.com/brave/adblock-lists/ma
 const BREAK_UNBREAK_URL = 'https://raw.githubusercontent.com/brave/adblock-lists/master/brave-unbreak.txt'
 const UBLOCK_UNBREAK_URL = 'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt'
 const NOTIFICATIONS_URL = 'https://easylist-downloads.adblockplus.org/fanboy-notifications.txt'
-const STATIC_RULE_URLS = [COIN_MINER_URL, BREAK_UNBREAK_URL, UBLOCK_UNBREAK_URL, NOTIFICATIONS_URL]
+const IOS_SPECIFIC_URL = 'https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-ios-specific.txt'
+const STATIC_RULE_URLS = [COIN_MINER_URL, BREAK_UNBREAK_URL, UBLOCK_UNBREAK_URL, NOTIFICATIONS_URL, IOS_SPECIFIC_URL]
 
 const REGIONAL_CATALOG_URL = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/regional.json'
 


### PR DESCRIPTION
Since removing the ios specific from [default.json used by the desktop](https://github.com/brave/adblock-resources/pull/28), we should adjust slimlist to pull this list directly instead. 

cc: @pes10k 