### PR TITLE
fetch domains from tranco

### DIFF
--- a/brave/tranco.js
+++ b/brave/tranco.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * @file
+ * Helper functions to fetch Tranco determined popular lists.
+ */
+
+const requestPromiseLib = require('request-promise')
+
+/**
+ *
+ */
+const get = async (count = 1000) => {
+  // First figure out what the ID of the current Tranco list is.
+  const trancoId = await requestPromiseLib('https://tranco-list.eu/top-1m-id')
+  const trancoUrl = `https://tranco-list.eu/download/${trancoId}/${count}`
+  const trancoRs = (await requestPromiseLib(trancoUrl)).trim()
+  return [trancoUrl, trancoRs.split('\r\n').map(line => line.split(',')[1])]
+}
+
+module.exports = {
+  get
+}


### PR DESCRIPTION
Slim list lambda used to fetch alexa lists from S3 (which were fetched from a different alexa fetching and caching lambda).  This PR instead fetches the lists directly from tranco.

This branch is off staging… i hope thats correct… 