### PR TITLE
Update repo url from brave-experiments to brave

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/brave-experiments/slim-list-lambda.git"
+    "url": "git+https://github.com/brave/slim-list-lambda.git"
   },
   "author": "Peter Snyder <pes@brave.com>",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/brave-experiments/slim-list-lambda/issues"
+    "url": "https://github.com/brave/slim-list-lambda/issues"
   },
-  "homepage": "https://github.com/brave-experiments/slim-list-lambda#readme",
+  "homepage": "https://github.com/brave/slim-list-lambda#readme",
   "dependencies": {
     "adblock-rs": "^0.3.7",
     "aws-sdk": "^2.574.0",


### PR DESCRIPTION
`brave-experiments` only appears in the package.json metadata, that link doesn't actually work anymore. But this PR updates it to the correct link (the repo in the `brave` org).