### PR TITLE
Fix for Segfault Error in Assemble Lambda

### DIFF
--- a/slim-list-lambdas.yaml
+++ b/slim-list-lambdas.yaml
@@ -688,7 +688,8 @@ Resources:
       Runtime: nodejs16.x
       CodeUri: ./build/slim-list-generator.zip
       Timeout: 900
-      MemorySize: 2048
+      MemorySize: 4096
+      EphemeralStorage: 2048
       Environment:
         Variables:
           DEBUG: !Ref DebugFlag


### PR DESCRIPTION
Resolve following segfault error in `assemble` lambda:

```
START RequestId: 427df6d1-9abe-4b90-9eda-1600835c9cf6 Version: $LATEST
2023-04-03T05:38:19.179Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Invocation: {"action":"assemble","slimListS3Bucket":"brave-adblock-data-staging","slimListS3Key":"slim-list/latest.json","readAcl":"id=9476f5dab14c3663a03e29668a27b4f35930942936793fded0bdd032eacd6e0924c024ef0d65b651b925adcd80cbc0d4","destS3Bucket":"brave-adblock-data-staging"}
2023-04-03T05:38:19.307Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Fetched 2006 rules from the slim list bucket.
2023-04-03T05:38:19.307Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	About to fetch and add rules from static lists
2023-04-03T05:38:20.165Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Successfully added rules from static lists, got 10851 rules in total
2023-04-03T05:38:20.165Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	About to convert default list to iOS content blocking syntax
2023-04-03T05:38:20.282Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Successfully converted 6586 into 6626 content blocking rules
2023-04-03T05:38:20.282Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	About to serialize a DAT from the successfully converted rules
2023-04-03T05:38:20.371Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Successfully serialized rules into buffer of length 281476
2023-04-03T05:38:20.383Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Saving the set of default rules used
2023-04-03T05:38:20.543Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Saving the new default content-blocking rules
2023-04-03T05:38:20.760Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Saving the new default DAT
2023-04-03T05:38:22.392Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	About to convert Liste AR to iOS content blocking syntax
2023-04-03T05:38:22.405Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Successfully converted 1811 into 1812 content blocking rules
2023-04-03T05:38:22.405Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	About to serialize a DAT from the successfully converted rules
2023-04-03T05:38:22.505Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Successfully serialized rules into buffer of length 141223
2023-04-03T05:38:22.508Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Saving the set of rules used from Liste AR
2023-04-03T05:38:22.652Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Saving the new content-blocking rules for Liste AR
2023-04-03T05:38:22.828Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	Saving the new DAT for Liste AR
2023-04-03T05:38:23.951Z	427df6d1-9abe-4b90-9eda-1600835c9cf6	INFO	About to convert Blocklists Anti-porn list to iOS content blocking syntax
RequestId: 427df6d1-9abe-4b90-9eda-1600835c9cf6 Error: Runtime exited with error: signal: segmentation fault
Runtime.ExitError
END RequestId: 427df6d1-9abe-4b90-9eda-1600835c9cf6
REPORT RequestId: 427df6d1-9abe-4b90-9eda-1600835c9cf6	Duration: 9830.76 ms	Billed Duration: 9831 ms	Memory Size: 2048 MB	Max Memory Used: 1233 MB	
XRAY TraceId: 1-642a664b-48bf3cba00743eed1267f628	SegmentId: 1f070c25439e54ae	Sampled: true	
```
