### PR TITLE
use `serialize_raw` for DAT generation

### DIFF
--- a/brave/adblock.js
+++ b/brave/adblock.js
@@ -17,9 +17,7 @@ const serializeRules = rules => {
     optimize: false
   }
   const adBlockClient = new adblockRsLib.Engine(filterSet, adBlockArgs)
-  // TODO migrate to `adBlockClient.serializeRaw()` once Brave iOS has
-  // supported reading it for long enough
-  const adBlockDat = adBlockClient.serializeCompressed()
+  const adBlockDat = adBlockClient.serializeRaw()
   const adBlockDatBuffer = Buffer.from(adBlockDat)
   braveDebugLib.verbose(`Successfully serialized rules into buffer of length ${adBlockDatBuffer.byteLength}`)
   return adBlockDatBuffer

--- a/brave/lambda_actions/assemble.js
+++ b/brave/lambda_actions/assemble.js
@@ -146,9 +146,7 @@ const convertRules = (rules, format) => {
   const iosFilterSet = new FilterSet(true)
   iosFilterSet.addFilters(filtersUsed)
   const engine = new Engine(iosFilterSet, { optimize: false })
-  // TODO migrate to `engine.serializeRaw()` once Brave iOS has supported it
-  // for long enough
-  const iosDat = engine.serializeCompressed()
+  const iosDat = engine.serializeRaw()
   const datBuffer = Buffer.from(iosDat)
 
   if (datBuffer.byteLength === 0) {


### PR DESCRIPTION
Support for this [newer format](https://github.com/brave/adblock-rust/releases/tag/v0.3.15) was [added](https://github.com/brave/brave-ios/pull/3895) in version 1.29 of `brave-ios`, which has been released for approximately [2 years](https://github.com/brave/brave-ios/releases/tag/v1.29) now. It should be safe to migrate over to the slightly more efficient uncompressed serialized format (which would also finally allow me to do some long-needed cleanup on the adblock-rust codebase).